### PR TITLE
Introduce DOM for SimpleEditor and Add a Basic Layout

### DIFF
--- a/Block.js
+++ b/Block.js
@@ -1,0 +1,101 @@
+import Style from "./Style.js"
+import Run from "./Run.js"
+
+export default class Block extends EventTarget {
+	#text
+	#style
+	#runs = []
+
+	constructor(text, runs) {
+		super()
+
+		this.#text = text
+		this.#runs = [...runs]
+
+		this[Symbol.iterator] = this.runs.bind(this)
+	}
+
+	get text() {
+		return this.#text
+	}
+
+	spliceText(offset, removeCount, insertText) {
+		// Normalize offset, which may be negative, to a positive index.
+		//
+		// Note that array splice will clamp values to be within the bounds of the array,
+		// but that we simply assert that to be the case as it would indicate a bug elsewhere.
+		if (offset < 0) {
+			offset = this.#text.length + offset
+			console.assert(offset >= 0)
+		}
+		console.assert(offset <= this.#text.length)
+
+		let chars = [...this.#text]
+		chars.splice(offset, removeCount, insertText)
+		this.#text = chars.join("")
+
+		// Update all the Runs in this Block to account for the new text.
+		let delta = offset - removeCount + insertText.length
+		let runs = []
+
+		for (let run of this.#runs) {
+			if (run.end < offset) {
+				runs.push(run)
+				continue
+			}
+
+			if (run.start > offset + removeCount) {
+				runs.push(new Run(run.start + delta, run.end + delta, run.style))
+				continue
+			}
+
+			if (run.start <= offset) {
+				// First run to intersect will cover all the insertedText,
+				// but it may not cover all the characters to be removed
+				let runEnd = Math.min(offset, run.end - removeCount) + insertText.length
+				runs.push(new Run(run.start, runEnd, run.style))
+
+				// removeCount is now remaining to be removed in subsequent Runs
+				removeCount = Math.min(0, removeCount - (run.end - offset))
+				continue
+			}
+
+			console.assert(run.start > offset)
+			if (run.length <= removeCount) {
+				// We don't need this Run, it's completely removed
+				removeCount = Math.min(0, removeCount - (run.length))
+				continue
+			}
+
+			console.assert(run.end > run.start + removeCount)
+			// The run length will decrease since we're removing characters from the Run.
+			// The start will not fully increase by delta but every Run after this can just
+			// have the start and end updated by delta.
+			let runStart = run.start - removeCount + insertText.length
+			runs.push(new Run(runStart, run.end + delta, run.style))
+		}
+
+		this.#runs = runs
+
+		this.dispatchEvent(new CustomEvent("changed"))
+	}
+
+	get style() {
+		return this.#style
+	}
+
+	set style(style) {
+		this.#style = style
+		this.dispatchEvent(new CustomEvent("changed"))
+	}
+
+	*runs() {
+		for(let i = 0; i < this.#runs.length; i++) {
+			yield this.#runs[i]
+		}
+	}
+
+	toString() {
+		return this.text
+	}
+}

--- a/BlockLayout.js
+++ b/BlockLayout.js
@@ -1,8 +1,10 @@
-export default class BlockLayout {
-	constructor() {
-	}
+import Line from "./Line.js"
+import Style from "./Style.js"
+import Run from "./Run.js"
 
+export default class BlockLayout {
 	static layoutBlock(block) {
-		return [{height: 13}, {height: 14}, {height: 15}]
+		// TODO: measure and break lines
+		return [new Line(block.text, [...block.runs()])]
 	}
 }

--- a/BlockLayout.js
+++ b/BlockLayout.js
@@ -1,4 +1,8 @@
 export default class BlockLayout {
 	constructor() {
 	}
+
+	static layoutBlock(block) {
+		return [{height: 13}, {height: 14}, {height: 15}]
+	}
 }

--- a/BlockLayout.js
+++ b/BlockLayout.js
@@ -1,0 +1,4 @@
+export default class BlockLayout {
+	constructor() {
+	}
+}

--- a/BlockLayout.js
+++ b/BlockLayout.js
@@ -1,10 +1,16 @@
 import Line from "./Line.js"
 import Style from "./Style.js"
-import Run from "./Run.js"
+import LayoutRun from "./LayoutRun.js"
 
 export default class BlockLayout {
-	static layoutBlock(block) {
+	static layoutBlock(block, ctx) {
 		// TODO: measure and break lines
-		return [new Line(block.text, [...block.runs()])]
+		let layoutRuns = [...block.runs()].map(r => {
+			ctx.font = r.style.font
+			let measure = ctx.measureText(block.text.slice(r.start, r.end))
+			return new LayoutRun(r.start, r.end, r.style, measure)
+		})
+
+		return [new Line(block.text, layoutRuns)]
 	}
 }

--- a/BlockLineCache.js
+++ b/BlockLineCache.js
@@ -1,0 +1,4 @@
+export default class BlockLineCache {
+	constructor() {
+	}
+}

--- a/BlockLineCache.js
+++ b/BlockLineCache.js
@@ -1,4 +1,19 @@
 export default class BlockLineCache {
+	#map
+
 	constructor() {
+		this.#map = new Map()
+	}
+
+	get(block) {
+		return this.#map.get(block)
+	}
+
+	set(block, lines) {
+		this.#map.set(block, lines)
+	}
+
+	delete(block) {
+		this.#map.delete(block)
 	}
 }

--- a/Color.js
+++ b/Color.js
@@ -1,0 +1,35 @@
+export default class Color {
+	#red
+	#green
+	#blue
+
+	constructor(red, green, blue) {
+		this.#red = red
+		this.#green = green
+		this.#blue = blue
+	}
+
+	get red() {
+		return this.#red
+	}
+
+	get green() {
+		return this.#green
+	}
+
+	get blue() {
+		return this.#blue
+	}
+
+	toString() {
+		return `rgb(${this.#red}, ${this.#green}, ${this.#blue})`
+	}
+
+	static random() {
+		let r = Math.floor(Math.random() * 256)
+		let g = Math.floor(Math.random() * 256)
+		let b = Math.floor(Math.random() * 256)
+
+		return new Color(r, g, b)
+	}
+}

--- a/LayoutRun.js
+++ b/LayoutRun.js
@@ -1,0 +1,15 @@
+import Run from "./Run.js"
+
+export default class LayoutRun extends Run {
+	#measure
+
+	constructor(start, end, style, measure) {
+		super(start, end, style)
+
+		this.#measure = measure
+	}
+
+	get measure() {
+		return this.#measure
+	}
+}

--- a/Line.js
+++ b/Line.js
@@ -4,6 +4,36 @@ export default class Line {
 
 	constructor(text, runs) {
 		this.#text = text
-		this.#runs = runs
+		this.#runs = [...runs]
+
+		this[Symbol.iterator] = this.runs.bind(this)
+	}
+
+	*runs() {
+		for (let i = 0; i < this.#runs.length; i++) {
+			yield this.#runs[i]
+		}
+	}
+
+	get ascent() {
+		let ascent = 0
+		for(let run of this.#runs) {
+			ascent = Math.max(ascent, run.measure.actualBoundingBoxAscent)
+		}
+
+		return ascent
+	}
+
+	get descent() {
+		let descent = 0
+		for(let run of this.#runs) {
+			descent = Math.max(descent, run.measure.actualBoundingBoxDescent)
+		}
+
+		return descent
+	}
+
+	get text() {
+		return this.#text
 	}
 }

--- a/Line.js
+++ b/Line.js
@@ -1,0 +1,9 @@
+export default class Line {
+	#text
+	#runs
+
+	constructor(text, runs) {
+		this.#text = text
+		this.#runs = runs
+	}
+}

--- a/ResizingCanvas.js
+++ b/ResizingCanvas.js
@@ -34,20 +34,26 @@ export default class ResizingCanvas extends EventTarget {
 		return this.#height
 	}
 
-	// handle resize events to reset the dimensions of the canvas 
+	// handle resize events to reset the dimensions of the canvas
+	//
+	// TODO: the canvas internal bitmap is no longer scaled to match device pixels
+	//       as it affects the intrinsic size (for some reason the device pixels values
+	//       are translated to CSS pixels when width and height are unconstrained).
+	//       As a result the canvas can't be used in "shrink-to-fit" scenarios, be
+	//       resized to its container, and simultaneously scaled for high DPI.
 	handleResize(entries) {
 		// only observing one element (our canvas) and assumes its not fragmented
 		console.assert(entries.length === 1)
-		console.assert(entries[0].target === this.canvas)
+		console.assert(entries[0].target === this.#canvas)
 
-		this.#width = entries[0].contentRect.width * devicePixelRatio
-		this.#height = entries[0].contentRect.height * devicePixelRatio
+		this.#width = entries[0].contentRect.width // * devicePixelRatio
+		this.#height = entries[0].contentRect.height // * devicePixelRatio
 
-		this.canvas.width = this.#width
-		this.canvas.height = this.#height
+		this.#canvas.width = this.#width
+		this.#canvas.height = this.#height
 
 		this.#ctx.resetTransform()
-		this.#ctx.scale(devicePixelRatio, devicePixelRatio)
+		//this.#ctx.scale(devicePixelRatio, devicePixelRatio)
 
 		this.dispatchEvent(new CustomEvent("resize"))		
 	}

--- a/Run.js
+++ b/Run.js
@@ -1,0 +1,29 @@
+import Style from "./Style.js"
+
+export default class Run {
+	#start
+	#end
+	#style
+
+	constructor(start, end, style) {
+		this.#start = start
+		this.#end = end
+		this.#style = style
+	}
+
+	get start() {
+		return this.#start
+	}
+
+	get end() {
+		return this.#end
+	}
+
+	get length() {
+		return this.#end - this.#start
+	}
+
+	get style() {
+		return this.#style
+	}
+}

--- a/SimpleEditor.js
+++ b/SimpleEditor.js
@@ -1,8 +1,10 @@
 import style from "./SimpleEditor.css"
 
 import SimpleEditorView from "./SimpleEditorView.js"
+import SimpleEditorDocument from "./SimpleEditorDocument.js"
 
 export class SimpleEditor extends HTMLElement {
+	#document
 	#view
 	#shadowRoot
 
@@ -12,7 +14,9 @@ export class SimpleEditor extends HTMLElement {
 		this.#shadowRoot = this.attachShadow({mode:"closed"})
 		this.#shadowRoot.adoptedStyleSheets = [style]
 
-		this.#view = new SimpleEditorView()
+		this.#document = new SimpleEditorDocument()
+		this.#view = new SimpleEditorView(this.#document)
+
 		this.#shadowRoot.append(this.#view.canvas)
 	}
 }

--- a/SimpleEditorDocument.js
+++ b/SimpleEditorDocument.js
@@ -1,5 +1,20 @@
 export default class SimpleEditorDocument extends EventTarget {
+	#blocks
+
 	constructor() {
 		super()
+
+		// demo data
+		this.#blocks = [ "Hello,", "World!" ]
+
+		// Make this document iterable over blocks
+		this[Symbol.iterator] = this.blocks.bind(this)
+	}
+
+	// A generator function for the blocks in this document
+	*blocks() {
+		for (let i = 0; i < this.#blocks.length; i++) {
+			yield this.#blocks[i]
+		}
 	}
 }

--- a/SimpleEditorDocument.js
+++ b/SimpleEditorDocument.js
@@ -1,0 +1,5 @@
+export default class SimpleEditorDocument extends EventTarget {
+	constructor() {
+		super()
+	}
+}

--- a/SimpleEditorDocument.js
+++ b/SimpleEditorDocument.js
@@ -1,3 +1,10 @@
+import Block from "./Block.js"
+
+// Imports for demo data creation
+import Run from "./Run.js"
+import Style from "./Style.js"
+import Color from "./Color.js"
+
 export default class SimpleEditorDocument extends EventTarget {
 	#blocks
 
@@ -5,7 +12,16 @@ export default class SimpleEditorDocument extends EventTarget {
 		super()
 
 		// demo data
-		this.#blocks = [ "Hello,", "World!" ]
+		let style = new Style(
+			/*fontFamily*/"sans-serif", 
+			/*fontSize*/"48px", 
+			/*fontWeight*/"bold", 
+			/*color*/Color.random()
+		)
+		this.#blocks = [ 
+			new Block("Hello,", [new Run(0, "Hello,".length, style)]), 
+			new Block("World!", [new Run(0, "World!".length, style)]) 
+		]
 
 		// Make this document iterable over blocks
 		this[Symbol.iterator] = this.blocks.bind(this)

--- a/SimpleEditorDocument.js
+++ b/SimpleEditorDocument.js
@@ -12,15 +12,24 @@ export default class SimpleEditorDocument extends EventTarget {
 		super()
 
 		// demo data
-		let style = new Style(
+		let style1 = new Style(
 			/*fontFamily*/"sans-serif", 
 			/*fontSize*/"48px", 
 			/*fontWeight*/"bold", 
 			/*color*/Color.random()
 		)
+		let style2 = new Style(
+			/*fontFamily*/"sans-serif", 
+			/*fontSize*/"64px", 
+			/*fontWeight*/"bold", 
+			/*color*/new Color(255, 0, 0)
+		)
 		this.#blocks = [ 
-			new Block("Hello,", [new Run(0, "Hello,".length, style)]), 
-			new Block("World!", [new Run(0, "World!".length, style)]) 
+			new Block("Hello, BIG", [
+				new Run(0, 7, style1),
+				new Run(7, 10, style2)
+			]), 
+			new Block("World!", [new Run(0, 6, style1)])
 		]
 
 		// Make this document iterable over blocks

--- a/SimpleEditorView.js
+++ b/SimpleEditorView.js
@@ -1,9 +1,18 @@
 import ResizingCanvas from "./ResizingCanvas.js"
+import BlockLayout from "./BlockLayout.js"
+import BlockLineCache from "./BlockLineCache.js"
 
 export default class SimpleEditorView {
 	#rc
+	#document
+	#blockLineCache
 
-	constructor(model) {
+	constructor(document) {
+		this.#document = document
+		this.#document.addEventListener("changed", this.handleDocumentChanged.bind(this))
+
+		this.#blockLineCache = new BlockLineCache()
+
 		this.#rc = new ResizingCanvas()
 		this.#rc.addEventListener("resize", this.handleResize.bind(this))
 	}
@@ -15,9 +24,12 @@ export default class SimpleEditorView {
 
 	// handle resize events to both reset the dimensions of the canvas 
 	// and reflow the text
-	handleResize(width, height) {
+	handleResize(e) {
 		let ctx = this.#rc.shared2dContext
 		ctx.fillStyle = "red"
 		ctx.fillRect(0, 0, this.#rc.width, this.#rc.height)
+	}
+
+	handleDocumentChanged(e) {
 	}
 }

--- a/SimpleEditorView.js
+++ b/SimpleEditorView.js
@@ -57,24 +57,35 @@ export default class SimpleEditorView {
 	renderCallback() {
 		this.#invalidated = false
 
+		const topMargin = 10
+		const leftMargin = 10
+
+		let lineTop = topMargin
+		let runOffset = leftMargin
+
+		let ctx = this.#rc.shared2dContext
+
 		for (let block of this.#document) {
 			let lines = this.#blockLineCache.get(block)
 			if (!lines) {
-				lines = BlockLayout.layoutBlock(block)
+				lines = BlockLayout.layoutBlock(block, ctx)
 				this.#blockLineCache.set(block, lines)
 			}
 
 			for (let line of lines) {
-				// render lines here
-				console.log(line)
+				for (let run of line) {
+					ctx.font = run.style.font
+					ctx.fillStyle = run.style.color
+
+					let text = line.text.slice(run.start, run.end)
+					ctx.fillText(text, runOffset, lineTop + line.ascent)
+
+					runOffset += run.measure.width
+				}
+
+				runOffset = leftMargin
+				lineTop += line.ascent + line.descent
 			}
 		}
-
-		let ctx = this.#rc.shared2dContext
-		ctx.fillStyle = Color.random().toString()
-		ctx.fillRect(0, 0, this.#rc.width, this.#rc.height)
-		ctx.fillStyle = Color.random().toString()
-		ctx.font = "bold 48px sans-serif"
-		ctx.fillText("Hello World!!!!!!!!!!!!!!!!!", 0, 100)
 	}
 }

--- a/SimpleEditorView.js
+++ b/SimpleEditorView.js
@@ -46,6 +46,10 @@ export default class SimpleEditorView {
 
 	// handle change events so layout can be updated then repainted
 	handleDocumentChanged(e) {
+		for (let block of e.changedBlocks) {
+			this.#blockLineCache.delete(block)
+		}
+		
 		this.invalidate()
 	}
 

--- a/SimpleEditorView.js
+++ b/SimpleEditorView.js
@@ -1,17 +1,22 @@
 import ResizingCanvas from "./ResizingCanvas.js"
 import BlockLayout from "./BlockLayout.js"
 import BlockLineCache from "./BlockLineCache.js"
+import Color from "./Color.js"
 
 export default class SimpleEditorView {
 	#rc
 	#document
 	#blockLineCache
+	#invalidated
+	#renderCallback
 
 	constructor(document) {
 		this.#document = document
 		this.#document.addEventListener("changed", this.handleDocumentChanged.bind(this))
 
 		this.#blockLineCache = new BlockLineCache()
+
+		this.#renderCallback = this.renderCallback.bind(this)
 
 		this.#rc = new ResizingCanvas()
 		this.#rc.addEventListener("resize", this.handleResize.bind(this))
@@ -22,14 +27,50 @@ export default class SimpleEditorView {
 		return this.#rc.canvas
 	}
 
-	// handle resize events to both reset the dimensions of the canvas 
-	// and reflow the text
-	handleResize(e) {
-		let ctx = this.#rc.shared2dContext
-		ctx.fillStyle = "red"
-		ctx.fillRect(0, 0, this.#rc.width, this.#rc.height)
+	// request that the view be repainted onto the canvas
+	invalidate() {
+		if (!this.#invalidated) {
+			this.#invalidated = true
+
+			// TODO: is this the best way?
+			// This will add one frame of delay to our updates, 
+			// but gives time for all events to be processed first.
+			requestAnimationFrame(this.#renderCallback)
+		}
 	}
 
+	// handle resize events so the text can reflow then repaint
+	handleResize(e) {
+		this.invalidate()
+	}
+
+	// handle change events so layout can be updated then repainted
 	handleDocumentChanged(e) {
+		this.invalidate()
+	}
+
+	// update layout, mark the view as valid and repaint
+	renderCallback() {
+		this.#invalidated = false
+
+		for (let block of this.#document) {
+			let lines = this.#blockLineCache.get(block)
+			if (!lines) {
+				lines = BlockLayout.layoutBlock(block)
+				this.#blockLineCache.set(block, lines)
+			}
+
+			for (let line of lines) {
+				// render lines here
+				console.log(line)
+			}
+		}
+
+		let ctx = this.#rc.shared2dContext
+		ctx.fillStyle = Color.random().toString()
+		ctx.fillRect(0, 0, this.#rc.width, this.#rc.height)
+		ctx.fillStyle = Color.random().toString()
+		ctx.font = "bold 48px sans-serif"
+		ctx.fillText("Hello World!!!!!!!!!!!!!!!!!", 0, 100)
 	}
 }

--- a/Style.js
+++ b/Style.js
@@ -1,0 +1,33 @@
+export default class Style {
+	#fontFamily
+	#fontSize
+	#fontWeight
+	#color
+
+	constructor(fontFamily, fontSize, fontWeight, color) {
+		this.#fontFamily = fontFamily
+		this.#fontSize = fontSize
+		this.#fontWeight = fontWeight
+		this.#color = color
+	}
+
+	get font() {
+		return `${this.fontWeight} ${this.fontSize} ${this.fontFamily}`
+	}
+
+	get fontFamily() {
+		return this.#fontFamily
+	}
+
+	get fontSize() {
+		return this.#fontSize
+	}
+
+	get fontWeight() {
+		return this.#fontWeight
+	}
+
+	get color() {
+		return this.#color
+	}
+}


### PR DESCRIPTION
Implement a DOM that is rooted by a SimpleEditorDocument.  The SimpleEditorDocument has N Blocks.  Blocks have text and N Runs that cover that text with Style (font and color).

A BlockLayout class takes the DOM as input and produces Lines as output.  Lines have enough information to drive the rendering of the DOM into the view.  Specifically, Lines hold the text that fits in the Line and LayoutRuns that cover the text.  LayoutRuns extend the concept of the Run to include TextMetrics.

In this change BlockLayout is simple and doesn't attempt to wrap Lines (so the text of each Block is displayed on a single Line).

Additionally an initial (and currently unused) implement of a spliceText method was introduced on the Block so that editing commands can be built on top of this primitive.